### PR TITLE
Add Tailwind Intellisense in VSCode for CVA calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,13 @@
         ],
         [
             "[\\w]+[cC]lassName[\"']?\\s*:\\s*`([^`]*)`"
+        ],
+        // https://cva.style/docs/getting-started/installation
+        [
+            "cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"
+        ],
+        [
+            "cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"
         ]
     ],
     // suggested by arktype


### PR DESCRIPTION
intellisense prompting when editing the initial cva function call with base style and variants working.
taken directly from docs